### PR TITLE
Update SupportQuota.pm

### DIFF
--- a/SupportQuota/Kernel/Output/HTML/SupportQuota.pm
+++ b/SupportQuota/Kernel/Output/HTML/SupportQuota.pm
@@ -56,7 +56,8 @@ sub Run {
         WHERE  cc.customer_id = (SELECT customer_id
                                 FROM    ticket
                                 WHERE   id = ?)
-               AND ta.time_unit IS NOT NULL";
+               AND ta.time_unit IS NOT NULL
+        GROUP BY cc.customer_id";
 
     # additional sql statement matching for the recurrence period
     my $Recurrence = $ConfigObject->Get('SupportQuota::Preferences::Recurrence');


### PR DESCRIPTION
cc.quota isn't a primary key, nor unique, so Postgres doesn't know which row to pick. Other databases pick random rows, but postgres follows the SQL standard and returns the error "ERROR: column "cc.quota" must appear in the GROUP BY clause or be used in an aggregate function".

Grouping by cc.customer_id should eliminate this error.